### PR TITLE
[fix]: input resize on mobile input focus

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,7 +15,7 @@ export default function Home() {
       <Head>
         <title>Chattr - Language Learning & Translation</title>
         <meta name="description" content="Real-time translation and AI-powered conversation for language learning" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main className={customSyles.main}>

--- a/src/styles/Home.module.scss
+++ b/src/styles/Home.module.scss
@@ -11,7 +11,8 @@ $input-height-mobile: calc($selector-height-mobile * 3 + $spacing-md * 2);
   gap: $spacing-md;
   align-items: center;
   padding: $spacing-xl $spacing-lg;
-  min-height: 100vh;
+  height: 100vh; /* fallback for browsers without dvh support */
+  height: 100dvh; /* tracks visual viewport on iOS when keyboard is open */
   overflow: hidden;
 
   .selectors {


### PR DESCRIPTION
1. Changing grid height to use `dvh`
2. Update to meta tags to handle similar situations